### PR TITLE
add a check to atq and clean up with atrm if needed

### DIFF
--- a/puppetctl
+++ b/puppetctl
@@ -21,6 +21,13 @@ enable(){
 
    if [ -f /var/lib/puppet/state/disabled.at ]; then
       rm -f /var/lib/puppet/state/disabled.at
+      for each in `atq | cut -f1`
+      do
+         if at -c $each | grep --quiet "rm -f /var/lib/puppet/state/disabled.at"
+         then
+            atrm $each
+         fi
+      done
       echo "Puppet has been enabled"
    else
       echo "Puppet is already enabled"


### PR DESCRIPTION
here's a scenario that bit me in production:

t+0hr: puppetctl disable -t "now + 3 hours" -m "deploying code"
t+1hr: puppetctl enable && puppetctl run
t+2hr: puppetctl disable -t "now + 3 days" -m "done for the weekend, will fix monday"
t+3hr: atd runs and enables puppet causing much chaos!

I typically don't write shellscripts for public consumption, so I'm not sure if this code is considered "good style", but I'm deploying this version to my network now and will continue testing it this week!
